### PR TITLE
feat: add option to load font from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,21 @@ const fontLigatures = require('font-ligatures');
 
 ### `load(name)`
 
-Loads the font with the given name, returning a Promise with a font that can be
-used to find ligature information.
+Loads the font with the given name, returning a Promise with a [Font](#font)
+that can be used to find ligature information.
 
 **Params**
 
  * `name` [*string*] - The font family of the font to load
+
+### `loadFile(path)`
+
+Loads the font at the given path, returning a Promise with a [Font](#font) that
+can be used to find ligature information.
+
+**Params**
+
+ * `path` [*string*] - Path to the file containing the font
 
 ### Font
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,17 @@ export async function load(name: string): Promise<Font> {
         throw new Error(`Font ${name} not found`);
     }
 
-    const font = await util.promisify<string, opentype.Font>(opentype.load as any)(fontInfo.path);
+    return loadFile(fontInfo.path);
+}
+
+/**
+ * Load the font at the given file path. The returned value can be used to find
+ * ligatures for the font.
+ *
+ * @param path Path to the file containing the font
+ */
+export async function loadFile(path: string): Promise<Font> {
+    const font = await util.promisify<string, opentype.Font>(opentype.load as any)(path);
     return new FontImpl(font);
 }
 


### PR DESCRIPTION
Adds a `loadFile(path)` function. It can be used by external consumers if they already know where the file is and also allows us to specify a file that isn't installed on the system (handy for portable benchmarks)