### PR TITLE
perf: short circuit ligature parsing when there are no lookup groups

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -29,6 +29,13 @@ test.before(t => {
                     type: fontFinder.Type.Monospace,
                     style: fontFinder.Style.Regular
                 }];
+            case 'Ubuntu Mono':
+                return [{
+                    path: path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf'),
+                    weight: 400,
+                    type: fontFinder.Type.Monospace,
+                    style: fontFinder.Style.Regular
+                }];
         }
     });
 });
@@ -48,6 +55,9 @@ const iosevka = (input: string, glyphs: number[], ranges: [number, number][]) =>
 
 const monoid = (input: string, glyphs: number[], ranges: [number, number][]) =>
     ({ font: 'Monoid', input, glyphs, ranges });
+
+const ubuntu = (input: string, glyphs: number[], ranges: [number, number][]) =>
+    ({ font: 'Ubuntu Mono', input, glyphs, ranges });
 
 const firaCases: Context[] = [
     fira('abc', [133, 145, 146], []),
@@ -289,7 +299,16 @@ const monoidCases: Context[] = [
     monoid('__', [763, 764], [[0, 2]])
 ];
 
-for (const { font, input, glyphs, ranges } of [...firaCases, ...iosevkaCases, ...monoidCases]) {
+const otherCases = [
+    ubuntu('==>', [32, 32, 33], [])
+];
+
+for (const { font, input, glyphs, ranges } of [
+    ...firaCases,
+    ...iosevkaCases,
+    ...monoidCases,
+    ...otherCases
+]) {
     test(`${font}: '${input}'`, async t => {
         const inst = await load(font);
         const result = inst.findLigatures(input);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,17 @@ class FontImpl implements Font {
             glyphIds.push(this._font.charToGlyphIndex(char));
         }
 
+        // If there are no lookup groups, there's no point looking for
+        // replacements. This gives us a minor performance boost for fonts with
+        // no ligatures
+        if (this._lookupGroups.length === 0) {
+            return {
+                inputGlyphs: glyphIds,
+                outputGlyphs: glyphIds,
+                contextRanges: []
+            };
+        }
+
         let result: number[] = glyphIds.slice();
         const individualContextRanges: [number, number][] = [];
 


### PR DESCRIPTION
With this enabled, I'm seeing a 15-20% improvement for calls where the font doesn't have any ligatures defined.

Related: https://github.com/princjef/font-ligatures/issues/2