### PR TITLE
feat: add ability to retrieve only the ligature ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ following keys:
    be rendered together to produce the ligatures in the output sequence. The
    ranges are inclusive on the left and exclusive on the right
 
+#### `findLigatureRanges(text)`
+
+Scans the provided text for font ligatures, returning an array of ranges where
+ligatures are located.
+
 **Params**
 
  * `text` [*string*] - text to search for ligatures

--- a/bench/all.js
+++ b/bench/all.js
@@ -19,49 +19,49 @@ setup(async () => {
 
 test('Fira Code: code.txt', (context, iteration) => {
     const line = code[iteration % code.length];
-    context.fira.findLigatures(line);
+    context.fira.findLigatureRanges(line);
     return line.length;
 });
 
 test('Fira Code: noLigatures.txt', (context, iteration) => {
     const line = noLigatures[iteration % noLigatures.length];
-    context.fira.findLigatures(line);
+    context.fira.findLigatureRanges(line);
     return line.length;
 });
 
 test('Iosevka: code.txt', (context, iteration) => {
     const line = code[iteration % code.length];
-    context.iosevka.findLigatures(line);
+    context.iosevka.findLigatureRanges(line);
     return line.length;
 });
 
 test('Iosevka: noLigatures.txt', (context, iteration) => {
     const line = noLigatures[iteration % noLigatures.length];
-    context.iosevka.findLigatures(line);
+    context.iosevka.findLigatureRanges(line);
     return line.length;
 });
 
 test('Monoid: code.txt', (context, iteration) => {
     const line = code[iteration % code.length];
-    context.monoid.findLigatures(line);
+    context.monoid.findLigatureRanges(line);
     return line.length;
 });
 
 test('Monoid: noLigatures.txt', (context, iteration) => {
     const line = noLigatures[iteration % noLigatures.length];
-    context.monoid.findLigatures(line);
+    context.monoid.findLigatureRanges(line);
     return line.length;
 });
 
 test('Ubuntu Mono: code.txt', (context, iteration) => {
     const line = code[iteration % code.length];
-    context.ubuntu.findLigatures(line);
+    context.ubuntu.findLigatureRanges(line);
     return line.length;
 });
 
 test('Ubuntu Mono: noLigatures.txt', (context, iteration) => {
     const line = noLigatures[iteration % noLigatures.length];
-    context.ubuntu.findLigatures(line);
+    context.ubuntu.findLigatureRanges(line);
     return line.length;
 });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -309,10 +309,16 @@ for (const { font, input, glyphs, ranges } of [
     ...monoidCases,
     ...otherCases
 ]) {
-    test(`${font}: '${input}'`, async t => {
+    test(`findLigatures() > ${font}: '${input}'`, async t => {
         const inst = await load(font);
         const result = inst.findLigatures(input);
         t.deepEqual(result.outputGlyphs, glyphs);
         t.deepEqual(result.contextRanges, ranges);
+    });
+
+    test(`findLigatureRanges() > ${font}: '${input}'`, async t => {
+        const inst = await load(font);
+        const result = inst.findLigatureRanges(input);
+        t.deepEqual(result, ranges);
     });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,4 +33,12 @@ export interface Font {
      * @param text String to search for ligatures
      */
     findLigatures(text: string): LigatureData;
+
+    /**
+     * Scans the provided text for font ligatures, returning an array of ranges
+     * where ligatures are located.
+     *
+     * @param text String to search for ligatures
+     */
+    findLigatureRanges(text: string): [number, number][];
 }


### PR DESCRIPTION
Adds `findLigatureRanges()` to go along with the existing `findLigatures()`. This new method takes the same inputs, but only returns the `contextRanges` part of the result. This allows some minor optimizations to allocations and a substantial optimization when working with font that have no ligatures.

In my tests, I see almost exactly a 10x improvement in parse time for fonts with no ligatures (down to 0.01-0.04 microseconds per character) and a 2-5% improvement in other cases.

Related: https://github.com/princjef/font-ligatures/issues/2