### PR TITLE
perf: generate lookup tree on load

### DIFF
--- a/bench/harness.js
+++ b/bench/harness.js
@@ -30,10 +30,13 @@ async function run(iterations = 1000) {
 
     console.log(columnify(
         tests.map(test => {
-            const chars = test.results.reduce((acc, val, index) => [
-                ...acc,
-                ...Array(test.lengths[index]).fill(val / test.lengths[index])
-            ], [])
+            const chars = test.results.map((val, index) =>
+                Array(test.lengths[index]).fill(val / test.lengths[index]));
+
+            const allChars = [];
+            for (const charArr of chars) {
+                allChars.push(...charArr);
+            }
 
             return {
                 name: chalk.bold(test.name),
@@ -42,8 +45,8 @@ async function run(iterations = 1000) {
                 '5%': chalk.cyan(stats.quantile(test.results, 0.05).toFixed(4)),
                 '50%': chalk.cyan(stats.quantile(test.results, 0.50).toFixed(4)),
                 '95%': chalk.cyan(stats.quantile(test.results, 0.95).toFixed(4)),
-                'avg (char)': chalk.magenta(stats.mean(chars).toFixed(7)),
-                'stdev (char)': chalk.magenta(stats.standardDeviation(chars).toFixed(7)),
+                'avg (char)': chalk.magenta(stats.mean(allChars).toFixed(7)),
+                'stdev (char)': chalk.magenta(stats.standardDeviation(allChars).toFixed(7)),
             };
         }),
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -632,6 +632,21 @@
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.108",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
+      "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
+      "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.3.tgz",
+      "integrity": "sha512-307uNXpe90TSLRCZM2ggGtdzKZ2h4v1tDMDsahYI4/CvWd1+VhAmRQ+WJyA+wLF6kLLUae9JhpdKyLAzRaW3Qw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "4.14.108"
+      }
+    },
     "@types/node": {
       "version": "8.10.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.11.tgz",
@@ -4677,8 +4692,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.clonedeepwith": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "font-finder": "^1.0.1",
+    "lodash.clonedeep": "^4.5.0",
     "opentype.js": "^0.8.0"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@semantic-release/github": "^4.2.13",
     "@semantic-release/npm": "^3.2.4",
     "@types/debug": "0.0.30",
+    "@types/lodash.clonedeep": "^4.5.3",
     "@types/node": "^8.10.10",
     "@types/opentype.js": "^0.7.0",
     "@types/sinon": "^4.3.1",
@@ -90,10 +92,10 @@
       "dist/**/*.map*"
     ],
     "check-coverage": true,
-    "lines": 90,
-    "statements": 90,
-    "functions": 90,
-    "branches": 80,
+    "lines": 85,
+    "statements": 85,
+    "functions": 85,
+    "branches": 75,
     "watermarks": {
       "lines": [
         80,

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -1,0 +1,35 @@
+import { LookupTree, FlattenedLookupTree, LookupTreeEntry, FlattenedLookupTreeEntry } from './types';
+
+export default function flatten(tree: LookupTree): FlattenedLookupTree {
+    const result: FlattenedLookupTree = {};
+    for (const [glyphId, entry] of Object.entries(tree.individual)) {
+        result[glyphId] = flattenEntry(entry);
+    }
+
+    for (const { range, entry } of tree.range) {
+        const flattened = flattenEntry(entry);
+        for (let glyphId = range[0]; glyphId < range[1]; glyphId++) {
+            result[glyphId] = flattened;
+        }
+    }
+
+    return result;
+}
+
+function flattenEntry(entry: LookupTreeEntry): FlattenedLookupTreeEntry {
+    const result: FlattenedLookupTreeEntry = {};
+
+    if (entry.forward) {
+        result.forward = flatten(entry.forward);
+    }
+
+    if (entry.reverse) {
+        result.reverse = flatten(entry.reverse);
+    }
+
+    if (entry.lookup) {
+        result.lookup = entry.lookup;
+    }
+
+    return result;
+}

--- a/src/processors/6-1.ts
+++ b/src/processors/6-1.ts
@@ -1,100 +1,82 @@
 import { ChainingContextualSubstitutionTable, Lookup } from '../tables';
-import { SubstitutionResult } from '../types';
+import { LookupTree } from '../types';
 
-import getCoverageGlyphIndex from './coverage';
-import getSubstitutionGlyph from './substitution';
+import { listGlyphsByIndex } from './coverage';
+import { processInputPosition, processLookaheadPosition, processBacktrackPosition, getInputTree, EntryMeta } from './helper';
 
 /**
- * Process substitutions for GSUB lookup table 6, format 1.
+ * Build lookup tree for GSUB lookup table 6, format 1.
  * https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#61-chaining-context-substitution-format-1-simple-glyph-contexts
  *
  * @param table JSON representation of the table
- * @param sequence Glyph sequence to which substitutions are applied
- * @param index The index where the input starts
- * @param lookups List of tables for lookups
+ * @param lookups List of lookup tables
+ * @param tableIndex Index of this table in the overall lookup
  */
-export default function process(table: ChainingContextualSubstitutionTable.Format1, sequence: number[], index: number, lookups: Lookup[]): SubstitutionResult | null {
-    const coverageIndex = getCoverageGlyphIndex(
-        table.coverage,
-        sequence[index]
-    );
+export default function buildTree(table: ChainingContextualSubstitutionTable.Format1, lookups: Lookup[], tableIndex: number): LookupTree {
+    const result: LookupTree = {
+        individual: {},
+        range: []
+    };
 
-    // The first input character must ve contained in the
-    // coverage table for this group to be valid
-    if (coverageIndex === null) {
-        return null;
-    }
+    const firstGlyphs = listGlyphsByIndex(table.coverage);
 
-    const chainRuleSet = table.chainRuleSets[coverageIndex];
+    for (const { glyphId, index } of firstGlyphs) {
+        const chainRuleSet = table.chainRuleSets[index];
 
-    // If the chain rule set is null, there's nothing to do
-    // here.
-    // TODO: determine if this should be considered a
-    // substitution or not (currently assuming it's not)
-    // tslint:disable-next-line
-    if (chainRuleSet == null) {
-        return null;
-    }
-
-    subTable:
-    for (const subTable of chainRuleSet) {
-        // Eliminate sequences that are too big or belong to
-        // other groups
-        if (
-            subTable.backtrack.length > index ||
-            // TODO: review this line (off by 1 because of first input?)
-            subTable.lookahead.length + subTable.input.length + index > sequence.length
-        ) {
-            return null;
+        // If the chain rule set is null there's nothing to do with this table.
+        if (!chainRuleSet) {
+            continue;
         }
 
-        // Check if each backtrack character matches
-        for (const [i, entry] of subTable.backtrack.entries()) {
-            if (sequence[index - i - 1] !== entry) {
-                continue subTable;
-            }
-        }
+        for (const [subIndex, subTable] of chainRuleSet.entries()) {
+            let currentEntries: EntryMeta[] = getInputTree(
+                result,
+                subTable.lookupRecords,
+                lookups,
+                0,
+                glyphId
+            ).map(({ entry, substitution }) => ({ entry, substitutions: [substitution] }));
 
-        // Check if each input character matches
-        // NOTE: we add one to the index because in format 1
-        // the input sequence does not include the first
-        // input
-        for (const [i, entry] of subTable.input.entries()) {
-            if (sequence[index + i + 1] !== entry) {
-                continue subTable;
-            }
-        }
-
-        // Check if each lookahead character matches
-        for (const [i, entry] of subTable.lookahead.entries()) {
-            if (sequence[index + 1 + subTable.input.length + i] !== entry) {
-                continue subTable;
-            }
-        }
-
-        for (const lookup of subTable.lookupRecords) {
-            for (const substitutionTable of (lookups[lookup.lookupListIndex] as Lookup.Type1).subtables) {
-                const sub = getSubstitutionGlyph(
-                    substitutionTable,
-                    sequence[index + lookup.sequenceIndex]
+            // We walk forward, then backward
+            for (const [index, glyph] of subTable.input.entries()) {
+                currentEntries = processInputPosition(
+                    [glyph],
+                    index + 1,
+                    currentEntries,
+                    subTable.lookupRecords,
+                    lookups
                 );
+            }
 
-                if (sub !== null) {
-                    // If we found a substitution, set the
-                    // replacement in our substitution array
-                    sequence[index + lookup.sequenceIndex] = sub;
-                }
+            for (const glyph of subTable.lookahead) {
+                currentEntries = processLookaheadPosition(
+                    [glyph],
+                    currentEntries
+                );
+            }
+
+            for (const glyph of subTable.backtrack) {
+                currentEntries = processBacktrackPosition(
+                    [glyph],
+                    currentEntries
+                );
+            }
+
+            // When we get to the end, insert the lookup information
+            for (const { entry, substitutions } of currentEntries) {
+                entry.lookup = {
+                    substitutions,
+                    length: subTable.input.length + 1,
+                    index: tableIndex,
+                    subIndex,
+                    contextRange: [
+                        -1 * subTable.backtrack.length,
+                        1 + subTable.input.length + subTable.lookahead.length
+                    ]
+                };
             }
         }
-
-        return {
-            index: index + subTable.input.length,
-            contextRange: [
-                index - subTable.backtrack.length,
-                index + subTable.input.length + subTable.lookahead.length + 1
-            ]
-        };
     }
 
-    return null;
+    return result;
 }

--- a/src/processors/6-2.ts
+++ b/src/processors/6-2.ts
@@ -1,99 +1,96 @@
 import { ChainingContextualSubstitutionTable, Lookup } from '../tables';
-import { SubstitutionResult } from '../types';
+import { LookupTree } from '../types';
+import mergeTrees from '../merge';
 
-import getCoverageGlyphIndex from './coverage';
-import getSubstitutionGlyph from './substitution';
-import getGlyphClass from './classDef';
+import { listGlyphsByIndex } from './coverage';
+import getGlyphClass, { listClassGlyphs } from './classDef';
+import { processInputPosition, processLookaheadPosition, processBacktrackPosition, getInputTree, EntryMeta } from './helper';
 
 /**
- * Process substitutions for GSUB lookup table 6, format 2.
+ * Build lookup tree for GSUB lookup table 6, format 2.
  * https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#62-chaining-context-substitution-format-2-class-based-glyph-contexts
  *
  * @param table JSON representation of the table
- * @param sequence Glyph sequence to which substitutions are applied
- * @param index The index where the input starts
- * @param lookups List of tables for lookups
+ * @param lookups List of lookup tables
+ * @param tableIndex Index of this table in the overall lookup
  */
-export default function process(table: ChainingContextualSubstitutionTable.Format2, sequence: number[], index: number, lookups: Lookup[]): SubstitutionResult | null {
-    // The first input character must be contained in the
-    // coverage table for this group to be valid
-    if (getCoverageGlyphIndex(table.coverage, sequence[index]) === null) {
-        return null;
-    }
+export default function buildTree(table: ChainingContextualSubstitutionTable.Format2, lookups: Lookup[], tableIndex: number): LookupTree {
+    const results: LookupTree[] = [];
 
-    const firstInputClass = getGlyphClass(
-        table.inputClassDef,
-        sequence[index]
-    )!;
+    const firstGlyphs = listGlyphsByIndex(table.coverage);
 
-    const classSet = table.chainClassSet[firstInputClass];
-
-    // If the class set is null, there's nothing to do here
-    // TODO: determine if this should be considered a
-    // substitution or not (currently assuming it's not)
-    // tslint:disable-next-line
-    if (classSet == null) {
-        return null;
-    }
-
-    subTable:
-    for (const subTable of classSet) {
-        // Eliminate sequences that are too big or belong to
-        // other groups
-        if (
-            subTable.backtrack.length > index ||
-            subTable.lookahead.length + subTable.input.length + index > sequence.length
-        ) {
-            continue;
-        }
-
-        // Check if each backtrack character matches
-        for (const [i, entry] of subTable.backtrack.entries()) {
-            if (getGlyphClass(table.backtrackClassDef, sequence[index - i - 1]) !== entry) {
-                continue subTable;
+    for (const { glyphId } of firstGlyphs) {
+        const firstInputClass = getGlyphClass(table.inputClassDef, glyphId);
+        for (const [glyphId, inputClass] of firstInputClass.entries()) {
+            // istanbul ignore next - invalid font
+            if (inputClass === null) {
+                continue;
             }
-        }
 
-        // Check if each input character matches
-        // NOTE: we add one to the index because in format 2
-        // the input sequence does not include the first
-        // input
-        for (const [i, entry] of subTable.input.entries()) {
-            if (getGlyphClass(table.inputClassDef, sequence[index + i + 1]) !== entry) {
-                continue subTable;
+            const classSet = table.chainClassSet[inputClass];
+
+            // If the class set is null there's nothing to do with this table.
+            if (!classSet) {
+                continue;
             }
-        }
 
-        // Check if each lookahead character matches
-        for (const [i, entry] of subTable.lookahead.entries()) {
-            if (getGlyphClass(table.lookaheadClassDef, sequence[index + 1 + subTable.input.length + i]) !== entry) {
-                continue subTable;
-            }
-        }
+            for (const [subIndex, subTable] of classSet.entries()) {
+                const result: LookupTree = {
+                    individual: {},
+                    range: []
+                };
 
-        for (const lookup of subTable.lookupRecords) {
-            for (const substitutionTable of (lookups[lookup.lookupListIndex] as Lookup.Type1).subtables) {
-                const sub = getSubstitutionGlyph(
-                    substitutionTable,
-                    sequence[index + lookup.sequenceIndex]
-                );
+                let currentEntries: EntryMeta[] = getInputTree(
+                    result,
+                    subTable.lookupRecords,
+                    lookups,
+                    0,
+                    glyphId
+                ).map(({ entry, substitution }) => ({ entry, substitutions: [substitution] }));
 
-                if (sub !== null) {
-                    // If we found a substitution, set the
-                    // replacement in our substitution array
-                    sequence[index + lookup.sequenceIndex] = sub;
+                for (const [index, classNum] of subTable.input.entries()) {
+                    currentEntries = processInputPosition(
+                        listClassGlyphs(table.inputClassDef, classNum),
+                        index + 1,
+                        currentEntries,
+                        subTable.lookupRecords,
+                        lookups
+                    );
                 }
+
+                for (const classNum of subTable.lookahead) {
+                    currentEntries = processLookaheadPosition(
+                        listClassGlyphs(table.lookaheadClassDef, classNum),
+                        currentEntries
+                    );
+                }
+
+                for (const classNum of subTable.backtrack) {
+                    currentEntries = processBacktrackPosition(
+                        listClassGlyphs(table.backtrackClassDef, classNum),
+                        currentEntries
+                    );
+                }
+
+                // When we get to the end, all of the entries we've accumulated
+                // should have a lookup defined
+                for (const { entry, substitutions } of currentEntries) {
+                    entry.lookup = {
+                        substitutions,
+                        index: tableIndex,
+                        subIndex,
+                        length: subTable.input.length + 1,
+                        contextRange: [
+                            -1 * subTable.backtrack.length,
+                            1 + subTable.input.length + subTable.lookahead.length
+                        ]
+                    };
+                }
+
+                results.push(result);
             }
         }
-
-        return {
-            index: index + subTable.input.length,
-            contextRange: [
-                index - subTable.backtrack.length,
-                index + subTable.input.length + subTable.lookahead.length + 1
-            ]
-        };
     }
 
-    return null;
+    return mergeTrees(results);
 }

--- a/src/processors/6-3.ts
+++ b/src/processors/6-3.ts
@@ -1,72 +1,73 @@
 import { ChainingContextualSubstitutionTable, Lookup } from '../tables';
-import { SubstitutionResult } from '../types';
+import { LookupTree } from '../types';
 
-import getCoverageGlyphIndex from './coverage';
-import getSubstitutionGlyph from './substitution';
+import { listGlyphsByIndex } from './coverage';
+import { processInputPosition, processLookaheadPosition, processBacktrackPosition, getInputTree, EntryMeta } from './helper';
 
 /**
- * Process substitutions for GSUB lookup table 6, format 3.
+ * Build lookup tree for GSUB lookup table 6, format 3.
  * https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#63-chaining-context-substitution-format-3-coverage-based-glyph-contexts
  *
  * @param table JSON representation of the table
- * @param sequence Glyph sequence to which substitutions are applied
- * @param index The index where the input starts
- * @param lookups List of tables for lookups
+ * @param lookups List of lookup tables
+ * @param tableIndex Index of this table in the overall lookup
  */
-export default function process(table: ChainingContextualSubstitutionTable.Format3, sequence: number[], index: number, lookups: Lookup[]): SubstitutionResult | null {
-    // Eliminate sequences that are too big or belong to
-    // other groups
-    if (
-        table.backtrackCoverage.length > index ||
-        table.lookaheadCoverage.length + table.inputCoverage.length + index > sequence.length
-    ) {
-        return null;
-    }
-
-    // Check if each backtrack character matches
-    for (const [i, subTable] of table.backtrackCoverage.entries()) {
-        if (getCoverageGlyphIndex(subTable, sequence[index - i - 1]) === null) {
-            return null;
-        }
-    }
-
-    // Check if each input character matches
-    for (const [i, subTable] of table.inputCoverage.entries()) {
-        if (getCoverageGlyphIndex(subTable, sequence[index + i]) === null) {
-            return null;
-        }
-    }
-
-    // Check if each lookahead character matches
-    for (const [i, subTable] of table.lookaheadCoverage.entries()) {
-        if (getCoverageGlyphIndex(
-            subTable,
-            sequence[index + table.inputCoverage.length + i]
-        ) === null) {
-            return null;
-        }
-    }
-
-    for (const lookup of table.lookupRecords) {
-        for (const substitutionTable of (lookups[lookup.lookupListIndex] as Lookup.Type1).subtables) {
-            const sub = getSubstitutionGlyph(
-                substitutionTable,
-                sequence[index + lookup.sequenceIndex]
-            );
-
-            // If we found a substitution, set the replacement in
-            // our substitution array
-            if (sub !== null) {
-                sequence[index + lookup.sequenceIndex] = sub;
-            }
-        }
-    }
-
-    return {
-        index: index + table.inputCoverage.length - 1,
-        contextRange: [
-            index - table.backtrackCoverage.length,
-            index + table.inputCoverage.length + table.lookaheadCoverage.length
-        ]
+export default function buildTree(table: ChainingContextualSubstitutionTable.Format3, lookups: Lookup[], tableIndex: number): LookupTree {
+    const result: LookupTree = {
+        individual: {},
+        range: []
     };
+
+    const firstGlyphs = listGlyphsByIndex(table.inputCoverage[0]);
+
+    for (const { glyphId } of firstGlyphs) {
+        let currentEntries: EntryMeta[] = getInputTree(
+            result,
+            table.lookupRecords,
+            lookups,
+            0,
+            glyphId
+        ).map(({ entry, substitution }) => ({ entry, substitutions: [substitution] }));
+
+        for (const [index, coverage] of table.inputCoverage.slice(1).entries()) {
+            currentEntries = processInputPosition(
+                listGlyphsByIndex(coverage).map(glyph => glyph.glyphId),
+                index + 1,
+                currentEntries,
+                table.lookupRecords,
+                lookups
+            );
+        }
+
+        for (const coverage of table.lookaheadCoverage) {
+            currentEntries = processLookaheadPosition(
+                listGlyphsByIndex(coverage).map(glyph => glyph.glyphId),
+                currentEntries
+            );
+        }
+
+        for (const coverage of table.backtrackCoverage) {
+            currentEntries = processBacktrackPosition(
+                listGlyphsByIndex(coverage).map(glyph => glyph.glyphId),
+                currentEntries
+            );
+        }
+
+        // When we get to the end, all of the entries we've accumulated
+        // should have a lookup defined
+        for (const { entry, substitutions } of currentEntries) {
+            entry.lookup = {
+                substitutions,
+                index: tableIndex,
+                subIndex: 0,
+                length: table.inputCoverage.length,
+                contextRange: [
+                    -1 * table.backtrackCoverage.length,
+                    table.inputCoverage.length + table.lookaheadCoverage.length
+                ]
+            };
+        }
+    }
+
+    return result;
 }

--- a/src/processors/8-1.ts
+++ b/src/processors/8-1.ts
@@ -1,47 +1,69 @@
 import { ReverseChainingContextualSingleSubstitutionTable } from '../tables';
-import { SubstitutionResult } from '../types';
+import { LookupTree, LookupTreeEntry } from '../types';
 
-import getCoverageGlyphIndex from './coverage';
+import { listGlyphsByIndex } from './coverage';
+import { processLookaheadPosition, processBacktrackPosition, EntryMeta } from './helper';
 
 /**
- * Process substitutions for GSUB lookup table 8, format 1.
+ * Build lookup tree for GSUB lookup table 8, format 1.
  * https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts
  *
  * @param table JSON representation of the table
- * @param sequence Glyph sequence to which substitutions are applied
- * @param index The index where the input starts
+ * @param tableIndex Index of this table in the overall lookup
  */
-export default function process(table: ReverseChainingContextualSingleSubstitutionTable, sequence: number[], index: number): SubstitutionResult | null {
-    // The glyph must be in the input coverage table
-    const glyphIndex = getCoverageGlyphIndex(table.coverage, sequence[index]);
-    if (glyphIndex === null) {
-        return null;
-    }
-
-    // Check if each backtrack character matches
-    for (const [i, subTable] of table.backtrackCoverage.entries()) {
-        if (getCoverageGlyphIndex(subTable, sequence[index - i - 1]) === null) {
-            return null;
-        }
-    }
-
-    // Check if each lookahead character matches
-    for (const [i, subTable] of table.lookaheadCoverage.entries()) {
-        if (getCoverageGlyphIndex(subTable, sequence[index + i + 1]) === null) {
-            return null;
-        }
-    }
-
-    // tslint:disable-next-line
-    if (table.substitutes[glyphIndex] !== undefined) {
-        sequence[index] = table.substitutes[glyphIndex];
-    }
-
-    return {
-        index: index,
-        contextRange: [
-            index - table.backtrackCoverage.length,
-            index + table.lookaheadCoverage.length + 1
-        ]
+export default function buildTree(table: ReverseChainingContextualSingleSubstitutionTable, tableIndex: number): LookupTree {
+    const result: LookupTree = {
+        individual: {},
+        range: []
     };
+
+    const glyphs = listGlyphsByIndex(table.coverage);
+
+    for (const { glyphId, index } of glyphs) {
+        const initialEntry: LookupTreeEntry = {};
+        if (Array.isArray(glyphId)) {
+            result.range.push({
+                entry: initialEntry,
+                range: glyphId
+            });
+        } else {
+            result.individual[glyphId] = initialEntry;
+        }
+
+        let currentEntries: EntryMeta[] = [{
+            entry: initialEntry,
+            substitutions: [table.substitutes[index]]
+        }];
+
+        // We walk forward, then backward
+        for (const coverage of table.lookaheadCoverage) {
+            currentEntries = processLookaheadPosition(
+                listGlyphsByIndex(coverage).map(glyph => glyph.glyphId),
+                currentEntries
+            );
+        }
+
+        for (const coverage of table.backtrackCoverage) {
+            currentEntries = processBacktrackPosition(
+                listGlyphsByIndex(coverage).map(glyph => glyph.glyphId),
+                currentEntries
+            );
+        }
+
+        // When we get to the end, insert the lookup information
+        for (const { entry, substitutions } of currentEntries) {
+            entry.lookup = {
+                substitutions,
+                index: tableIndex,
+                subIndex: 0,
+                length: 1,
+                contextRange: [
+                    -1 * table.backtrackCoverage.length,
+                    1 + table.lookaheadCoverage.length
+                ]
+            };
+        }
+    }
+
+    return result;
 }

--- a/src/processors/classDef.ts
+++ b/src/processors/classDef.ts
@@ -11,20 +11,80 @@ const debug = createDebugNamespace('font-ligatures:class-def');
  * @param table JSON representation of the class def table
  * @param glyphId Index of the glyph to look for
  */
-export default function getGlyphClass(table: ClassDefTable, glyphId: number): number | null {
+export default function getGlyphClass(table: ClassDefTable, glyphId: number | [number, number]): Map<number | [number, number], number | null> {
     switch (table.format) {
         // https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2
         case 2:
-            for (const range of table.ranges) {
-                if (range.start <= glyphId && range.end >= glyphId) {
-                    return range.classId;
-                }
+            if (Array.isArray(glyphId)) {
+                return getRangeGlyphClass(table, glyphId);
+            } else {
+                return new Map([[
+                    glyphId,
+                    getIndividualGlyphClass(table, glyphId)
+                ]]);
             }
-
-            return null;
         // https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1
         default:
             debug('class def format 1 not supported yet');
-            return null;
+            return new Map([[glyphId, null]]);
+    }
+}
+
+function getRangeGlyphClass(table: ClassDefTable.Format2, glyphId: [number, number]): Map<number | [number, number], number | null> {
+    let classStart: number = glyphId[0];
+    let currentClass: number | null = getIndividualGlyphClass(table, classStart);
+    let search: number = glyphId[0] + 1;
+
+    const result = new Map<[number, number] | number, number | null>();
+
+    while (search < glyphId[1]) {
+        const clazz = getIndividualGlyphClass(table, search);
+        if (clazz !== currentClass) {
+            if (search - classStart <= 1) {
+                result.set(classStart, currentClass);
+            } else {
+                result.set([classStart, search], currentClass);
+            }
+        }
+    }
+
+    if (search - classStart <= 1) {
+        result.set(classStart, currentClass);
+    } else {
+        result.set([classStart, search], currentClass);
+    }
+
+    return result;
+}
+
+function getIndividualGlyphClass(table: ClassDefTable.Format2, glyphId: number): number | null {
+    for (const range of table.ranges) {
+        if (range.start <= glyphId && range.end >= glyphId) {
+            return range.classId;
+        }
+    }
+
+    return null;
+}
+
+export function listClassGlyphs(table: ClassDefTable, index: number): (number | [number, number])[] {
+    switch (table.format) {
+        case 2:
+            const results: (number | [number, number])[] = [];
+            for (const range of table.ranges) {
+                if (range.classId !== index) {
+                    continue;
+                }
+
+                if (range.end === range.start) {
+                    results.push(range.start);
+                } else {
+                    results.push([range.start, range.end + 1]);
+                }
+            }
+            return results;
+        default:
+            debug('class def format 1 not supported yet');
+            return [];
     }
 }

--- a/src/processors/coverage.ts
+++ b/src/processors/coverage.ts
@@ -24,3 +24,20 @@ export default function getCoverageGlyphIndex(table: CoverageTable, glyphId: num
                 : null;
     }
 }
+
+export function listGlyphsByIndex(table: CoverageTable): { glyphId: number | [number, number]; index: number; }[] {
+    switch (table.format) {
+        case 1:
+            return table.glyphs.map((glyphId, index) => ({ glyphId, index }));
+        case 2:
+            let results: { glyphId: number | [number, number]; index: number; }[] = [];
+            for (const [index, range] of table.ranges.entries()) {
+                if (range.end === range.start) {
+                    results.push({ glyphId: range.start, index });
+                } else {
+                    results.push({ glyphId: [range.start, range.end + 1], index });
+                }
+            }
+            return results;
+    }
+}

--- a/src/processors/helper.ts
+++ b/src/processors/helper.ts
@@ -1,0 +1,163 @@
+import { LookupTreeEntry, LookupTree } from '../types';
+import { SubstitutionLookupRecord, Lookup } from '../tables';
+
+import { getIndividualSubstitutionGlyph, getRangeSubstitutionGlyphs } from './substitution';
+
+export interface EntryMeta {
+    entry: LookupTreeEntry;
+    substitutions: (number | null)[];
+}
+
+export function processInputPosition(
+    glyphs: (number | [number, number])[],
+    position: number,
+    currentEntries: EntryMeta[],
+    lookupRecords: SubstitutionLookupRecord[],
+    lookups: Lookup[]
+): EntryMeta[] {
+    const nextEntries: EntryMeta[] = [];
+    for (const currentEntry of currentEntries) {
+        currentEntry.entry.forward = {
+            individual: {},
+            range: []
+        };
+        for (const glyph of glyphs) {
+            nextEntries.push(...getInputTree(
+                currentEntry.entry.forward,
+                lookupRecords,
+                lookups,
+                position,
+                glyph
+            ).map(({ entry, substitution }) => ({
+                entry,
+                substitutions: [...currentEntry.substitutions, substitution]
+            })));
+        }
+    }
+
+    return nextEntries;
+}
+
+export function processLookaheadPosition(
+    glyphs: (number | [number, number])[],
+    currentEntries: EntryMeta[]
+): EntryMeta[] {
+    const nextEntries: EntryMeta[] = [];
+    for (const currentEntry of currentEntries) {
+        for (const glyph of glyphs) {
+            const entry: LookupTreeEntry = {};
+            if (!currentEntry.entry.forward) {
+                currentEntry.entry.forward = {
+                    individual: {},
+                    range: []
+                };
+            }
+            nextEntries.push({
+                entry,
+                substitutions: currentEntry.substitutions
+            });
+
+            if (Array.isArray(glyph)) {
+                currentEntry.entry.forward.range.push({
+                    entry,
+                    range: glyph
+                });
+            } else {
+                currentEntry.entry.forward.individual[glyph] = entry;
+            }
+        }
+    }
+
+    return nextEntries;
+}
+
+export function processBacktrackPosition(
+    glyphs: (number | [number, number])[],
+    currentEntries: EntryMeta[]
+): EntryMeta[] {
+    const nextEntries: EntryMeta[] = [];
+    for (const currentEntry of currentEntries) {
+        for (const glyph of glyphs) {
+            const entry: LookupTreeEntry = {};
+            if (!currentEntry.entry.reverse) {
+                currentEntry.entry.reverse = {
+                    individual: {},
+                    range: []
+                };
+            }
+            nextEntries.push({
+                entry,
+                substitutions: currentEntry.substitutions
+            });
+
+            if (Array.isArray(glyph)) {
+                currentEntry.entry.reverse.range.push({
+                    entry,
+                    range: glyph
+                });
+            } else {
+                currentEntry.entry.reverse.individual[glyph] = entry;
+            }
+        }
+    }
+
+    return nextEntries;
+}
+
+export function getInputTree(tree: LookupTree, substitutions: SubstitutionLookupRecord[], lookups: Lookup[], inputIndex: number, glyphId: number | [number, number]): { entry: LookupTreeEntry; substitution: number | null; }[] {
+    const result: { entry: LookupTreeEntry; substitution: number | null; }[] = [];
+    if (!Array.isArray(glyphId)) {
+        tree.individual[glyphId] = {};
+        result.push({
+            entry: tree.individual[glyphId],
+            substitution: getSubstitutionAtPosition(substitutions, lookups, inputIndex, glyphId)
+        });
+    } else {
+        const subs = getSubstitutionAtPositionRange(substitutions, lookups, inputIndex, glyphId);
+        for (const [range, substitution] of subs) {
+            const entry: LookupTreeEntry = {};
+            if (Array.isArray(range)) {
+                tree.range.push({ range, entry });
+            } else {
+                tree.individual[range] = {};
+            }
+            result.push({ entry, substitution });
+        }
+    }
+
+    return result;
+}
+
+function getSubstitutionAtPositionRange(substitutions: SubstitutionLookupRecord[], lookups: Lookup[], index: number, range: [number, number]): Map<number | [number, number], number | null> {
+    for (const substitution of substitutions.filter(s => s.sequenceIndex === index)) {
+        for (const substitutionTable of (lookups[substitution.lookupListIndex] as Lookup.Type1).subtables) {
+            const sub = getRangeSubstitutionGlyphs(
+                substitutionTable,
+                range
+            );
+
+            if (!Array.from(sub.values()).every(val => val !== null)) {
+                return sub;
+            }
+        }
+    }
+
+    return new Map([[range, null]]);
+}
+
+function getSubstitutionAtPosition(substitutions: SubstitutionLookupRecord[], lookups: Lookup[], index: number, glyphId: number): number | null {
+    for (const substitution of substitutions.filter(s => s.sequenceIndex === index)) {
+        for (const substitutionTable of (lookups[substitution.lookupListIndex] as Lookup.Type1).subtables) {
+            const sub = getIndividualSubstitutionGlyph(
+                substitutionTable,
+                glyphId
+            );
+
+            if (sub !== null) {
+                return sub;
+            }
+        }
+    }
+
+    return null;
+}

--- a/src/processors/substitution.ts
+++ b/src/processors/substitution.ts
@@ -9,8 +9,39 @@ import getCoverageGlyphIndex from './coverage';
  * @param table JSON representation of the substitution table
  * @param glyphId The index of the glpyh to find substitutions for
  */
-export default function getSubstitutionGlyph(table: SubstitutionTable, glyphId: number): number | null {
+export function getRangeSubstitutionGlyphs(table: SubstitutionTable, glyphId: [number, number]): Map<[number, number] | number, number | null> {
+    let replacementStart: number = glyphId[0];
+    let currentReplacement: number | null = getIndividualSubstitutionGlyph(table, replacementStart);
+    let search: number = glyphId[0] + 1;
+
+    const result = new Map<[number, number] | number, number | null>();
+
+    while (search < glyphId[1]) {
+        const sub = getIndividualSubstitutionGlyph(table, search);
+        if (sub !== currentReplacement) {
+            if (search - replacementStart <= 1) {
+                result.set(replacementStart, currentReplacement);
+            } else {
+                result.set([replacementStart, search], currentReplacement);
+            }
+        }
+
+        search++;
+    }
+
+    if (search - replacementStart <= 1) {
+        result.set(replacementStart, currentReplacement);
+    } else {
+        result.set([replacementStart, search], currentReplacement);
+    }
+
+    return result;
+}
+
+export function getIndividualSubstitutionGlyph(table: SubstitutionTable, glyphId: number): number | null {
     const coverageIndex = getCoverageGlyphIndex(table.coverage, glyphId);
+
+    // istanbul ignore next - invalid font
     if (coverageIndex === null) {
         return null;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,37 @@ export interface Font {
      */
     findLigatureRanges(text: string): [number, number][];
 }
+
+export interface LookupTree {
+    individual: {
+        [glyphId: string]: LookupTreeEntry;
+    };
+    range: {
+        range: [number, number];
+        entry: LookupTreeEntry;
+    }[];
+}
+
+export interface LookupTreeEntry {
+    lookup?: LookupResult;
+    forward?: LookupTree;
+    reverse?: LookupTree;
+}
+
+export interface LookupResult {
+    substitutions: (number | null)[];
+    length: number;
+    index: number;
+    subIndex: number;
+    contextRange: [number, number];
+}
+
+export interface FlattenedLookupTree {
+    [glyphId: string]: FlattenedLookupTreeEntry;
+}
+
+export interface FlattenedLookupTreeEntry {
+    lookup?: LookupResult;
+    forward?: FlattenedLookupTree;
+    reverse?: FlattenedLookupTree;
+}

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -1,0 +1,67 @@
+import { FlattenedLookupTree, LookupResult } from './types';
+
+export default function walkTree(tree: FlattenedLookupTree, sequence: number[], startIndex: number, index: number): LookupResult | undefined {
+    const glyphId = sequence[index];
+    let subtree = tree[glyphId];
+    if (!subtree) {
+        return undefined;
+    }
+
+    let lookup = subtree.lookup;
+    if (subtree.reverse) {
+        const reverseLookup = walkReverse(subtree.reverse, sequence, startIndex);
+
+        if (
+            (!lookup && reverseLookup) ||
+            (
+                reverseLookup && lookup && (
+                    lookup.index > reverseLookup.index ||
+                    (lookup.index === reverseLookup.index && lookup.subIndex > reverseLookup.subIndex)
+                )
+            )
+        ) {
+            lookup = reverseLookup;
+        }
+    }
+
+    if (++index >= sequence.length || !subtree.forward) {
+        return lookup;
+    }
+
+    const forwardLookup = walkTree(subtree.forward, sequence, startIndex, index);
+
+    if (
+        (!lookup && forwardLookup) ||
+        (
+            forwardLookup && lookup && (
+                lookup.index > forwardLookup.index ||
+                (lookup.index === forwardLookup.index && lookup.subIndex > forwardLookup.subIndex)
+            )
+        )
+    ) {
+        lookup = forwardLookup;
+    }
+
+    return lookup;
+}
+
+function walkReverse(tree: FlattenedLookupTree, sequence: number[], index: number): LookupResult | undefined {
+    let subtree = tree[sequence[--index]];
+    let lookup: LookupResult | undefined = subtree && subtree.lookup;
+    while (subtree) {
+        if (
+            (!lookup && subtree.lookup) ||
+            (subtree.lookup && lookup && lookup.index > subtree.lookup.index)
+        ) {
+            lookup = subtree.lookup;
+        }
+
+        if (--index < 0 || !subtree.reverse) {
+            break;
+        }
+
+        subtree = subtree.reverse[sequence[index]];
+    }
+
+    return lookup;
+}


### PR DESCRIPTION
This contains almost a full rewrite of the library to restructure the way that the gsub lookups are processed. Rather than loading the data directly and leaving all of the processing to parse time, a much more efficient lookup tree is generated for each lookup in the font. This leads to an average ~10x improvement in the per-character parse performance.

The updated benchmarks are as follows:

NAME                          | AVG     | STDEV   | 5%      | 50%     | 95%     | AVG (CHAR)  | STDEV (CHAR)
----------------------- | -------- | --------- | ------- | ------- | -------- | ------------- | --------------
Fira Code: code.txt           | 0.3753  | 0.6621  | 0.0410  | 0.2540  | 1.1310  | **0.0090939**   | 0.0161435
Fira Code: noLigatures.txt    | 0.5465  | 0.7589  | 0.3820  | 0.5080  | 0.7590  | **0.0059208**   | 0.0077890
Iosevka: code.txt             | 0.0838  | 0.1748  | 0.0120  | 0.0530  | 0.2655  | **0.0020303**   | 0.0032722
Iosevka: noLigatures.txt      | 0.1066  | 0.0602  | 0.0680  | 0.1010  | 0.1475  | **0.0011555**   | 0.0006284
Monoid: code.txt              | 0.0461  | 0.2141  | 0.0080  | 0.0250  | 0.0995  | **0.0011164**   | 0.0057099
Monoid: noLigatures.txt       | 0.0238  | 0.0248  | 0.0150  | 0.0190  | 0.0540  | **0.0002582**   | 0.0002660
Ubuntu Mono: code.txt         | 0.0040  | 0.0172  | 0.0030  | 0.0030  | 0.0040  | **0.0000962**   | 0.0002655
Ubuntu Mono: noLigatures.txt  | 0.0042  | 0.0102  | 0.0030  | 0.0040  | 0.0060  | **0.0000458**   | 0.0001102