### PR TITLE
perf: merge context ranges as they're found

### DIFF
--- a/src/mergeRange.spec.ts
+++ b/src/mergeRange.spec.ts
@@ -1,0 +1,43 @@
+import test from 'ava';
+
+import mergeRange from './mergeRange';
+
+test('inserts a new range before the existing ones', t => {
+    const result = mergeRange([[1, 2], [2, 3]], 0, 1);
+    t.deepEqual(result, [[0, 1], [1, 2], [2, 3]]);
+});
+
+test('inserts in between two ranges', t => {
+    const result = mergeRange([[0, 2], [4, 6]], 2, 4);
+    t.deepEqual(result, [[0, 2], [2, 4], [4, 6]]);
+});
+
+test('inserts after the last range', t => {
+    const result = mergeRange([[0, 2], [4, 6]], 6, 8);
+    t.deepEqual(result, [[0, 2], [4, 6], [6, 8]]);
+});
+
+test('extends the beginning of a range', t => {
+    const result = mergeRange([[0, 2], [4, 6]], 3, 5);
+    t.deepEqual(result, [[0, 2], [3, 6]]);
+});
+
+test('extends the end of a range', t => {
+    const result = mergeRange([[0, 2], [4, 6]], 1, 4);
+    t.deepEqual(result, [[0, 4], [4, 6]]);
+});
+
+test('extends the last range', t => {
+    const result = mergeRange([[0, 2], [4, 6]], 5, 7);
+    t.deepEqual(result, [[0, 2], [4, 7]]);
+});
+
+test('connects two ranges', t => {
+    const result = mergeRange([[0, 2], [4, 6]], 1, 5);
+    t.deepEqual(result, [[0, 6]]);
+});
+
+test('connects more than two ranges', t => {
+    const result = mergeRange([[0, 2], [4, 6], [8, 10], [12, 14]], 1, 10);
+    t.deepEqual(result, [[0, 10], [12, 14]]);
+});

--- a/src/mergeRange.ts
+++ b/src/mergeRange.ts
@@ -1,0 +1,64 @@
+/**
+ * Merges the range defined by the provided start and end into the list of
+ * existing ranges. The merge is done in place on the existing range for
+ * performance and is also returned.
+ *
+ * @param ranges Existing range list
+ * @param newRangeStart Start position of the range to merge, inclusive
+ * @param newRangeEnd End position of range to merge, exclusive
+ */
+export default function mergeRange(ranges: [number, number][], newRangeStart: number, newRangeEnd: number): [number, number][] {
+    let inRange = false;
+    for (let i = 0; i < ranges.length; i++) {
+        const range = ranges[i];
+        if (!inRange) {
+            if (newRangeEnd <= range[0]) {
+                // Case 1: New range is before the search range
+                ranges.splice(i, 0, [newRangeStart, newRangeEnd]);
+                return ranges;
+            } else if (newRangeEnd <= range[1]) {
+                // Case 2: New range is either wholly contained within the
+                // search range or overlaps with the front of it
+                range[0] = Math.min(newRangeStart, range[0]);
+                return ranges;
+            } else if (newRangeStart < range[1]) {
+                // Case 3: New range either wholly contains the search range
+                // or overlaps with the end of it
+                range[0] = Math.min(newRangeStart, range[0]);
+                inRange = true;
+            } else {
+                // Case 4: New range starts after the search range
+                continue;
+            }
+        } else {
+            if (newRangeEnd <= range[0]) {
+                // Case 5: New range extends from previous range but doesn't
+                // reach the current one
+                ranges[i - 1][1] = newRangeEnd;
+                return ranges;
+            } else if (newRangeEnd <= range[1]) {
+                // Case 6: New range extends from prvious range into the
+                // current range
+                ranges[i - 1][1] = Math.max(newRangeEnd, range[1]);
+                ranges.splice(i, 1);
+                inRange = false;
+                return ranges;
+            } else {
+                // Case 7: New range extends from previous range past the
+                // end of the current range
+                ranges.splice(i, 1);
+                i--;
+            }
+        }
+    }
+
+    if (inRange) {
+        // Case 8: New range extends past the last existing range
+        ranges[ranges.length - 1][1] = newRangeEnd;
+    } else {
+        // Case 9: New range starts after the last existing range
+        ranges.push([newRangeStart, newRangeEnd]);
+    }
+
+    return ranges;
+}


### PR DESCRIPTION
Each time a substitution is found for a range of text, the range of characters needed to match the substitution is tracked to determine the characters that need to be rendered together to produce the correct ligature. These context ranges can overlap, so they must be merged before returning. Currently, the ranges are all collected up and then merged at the end into new ranges. This change merges them as they are found to reduce the memory footprint and the computation to sort and merge them at the end.

The performance gain here is very small. The numbers are slight enough that it's hard to get a good feel for it, but it's probably somewhere in the range of 5-10% overall when text contains ligatures, which is enough to make it worthwhile (especially since it makes the code a little more readable too).

Related: #2 