### PR TITLE
feat(cache): add option to cache previous results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 
 *.tgz
 npm-debug.log*
+heapdump-*

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ bench/
 
 *.tgz
 npm-debug.log*
+heapdump-*

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const fontLigatures = require('font-ligatures');
 
 ## API
 
-### `load(name)`
+### `load(name, [options])`
 
 Loads the font with the given name, returning a Promise with a [Font](#font)
 that can be used to find ligature information.
@@ -37,8 +37,13 @@ that can be used to find ligature information.
 **Params**
 
  * `name` [*string*] - The font family of the font to load
+ * `options` [*object*] - Optional configuration object containing the following
+   keys:
+    * `cacheSize` [*number*] - The amount of data from previous results to cache
+      within the parser. The size is measured by the length of the input text
+      for each call. Turned off by default.
 
-### `loadFile(path)`
+### `loadFile(path, [options])`
 
 Loads the font at the given path, returning a Promise with a [Font](#font) that
 can be used to find ligature information.
@@ -46,6 +51,11 @@ can be used to find ligature information.
 **Params**
 
  * `path` [*string*] - Path to the file containing the font
+ * `options` [*object*] - Optional configuration object containing the following
+   keys:
+    * `cacheSize` [*number*] - The amount of data from previous results to cache
+      within the parser. The size is measured by the length of the input text
+      for each call. Turned off by default.
 
 ### Font
 

--- a/bench/all.js
+++ b/bench/all.js
@@ -8,61 +8,206 @@ const { setup, test, run } = require('./harness');
 const code = fs.readFileSync(path.join(__dirname, 'code.txt'), 'utf8').split('\n');
 const noLigatures = fs.readFileSync(path.join(__dirname, 'no-ligatures.txt'), 'utf8').split('\n');
 
-setup(async () => {
-    return {
-        fira: await fontLigatures.loadFile(path.join(__dirname, '../fonts/FiraCode-Regular.otf')),
-        iosevka: await fontLigatures.loadFile(path.join(__dirname, '../fonts/iosevka-regular.ttf')),
-        monoid: await fontLigatures.loadFile(path.join(__dirname, '../fonts/Monoid-Regular.ttf')),
-        ubuntu: await fontLigatures.loadFile(path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf')),
-    };
+const cacheSize = 10000;
+
+test('Fira Code: code', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/FiraCode-Regular.otf')));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Fira Code: code.txt', (context, iteration) => {
-    const line = code[iteration % code.length];
-    context.fira.findLigatureRanges(line);
-    return line.length;
+test('Fira Code: no-ligatures', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/FiraCode-Regular.otf')));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Fira Code: noLigatures.txt', (context, iteration) => {
-    const line = noLigatures[iteration % noLigatures.length];
-    context.fira.findLigatureRanges(line);
-    return line.length;
+test('Fira Code: code (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/FiraCode-Regular.otf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Iosevka: code.txt', (context, iteration) => {
-    const line = code[iteration % code.length];
-    context.iosevka.findLigatureRanges(line);
-    return line.length;
+test('Fira Code: no-ligatures (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/FiraCode-Regular.otf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Iosevka: noLigatures.txt', (context, iteration) => {
-    const line = noLigatures[iteration % noLigatures.length];
-    context.iosevka.findLigatureRanges(line);
-    return line.length;
+test('Iosevka: code', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/iosevka-regular.ttf')));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Monoid: code.txt', (context, iteration) => {
-    const line = code[iteration % code.length];
-    context.monoid.findLigatureRanges(line);
-    return line.length;
+test('Iosevka: no-ligatures', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/iosevka-regular.ttf')));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Monoid: noLigatures.txt', (context, iteration) => {
-    const line = noLigatures[iteration % noLigatures.length];
-    context.monoid.findLigatureRanges(line);
-    return line.length;
+test('Iosevka: code (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/iosevka-regular.ttf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Ubuntu Mono: code.txt', (context, iteration) => {
-    const line = code[iteration % code.length];
-    context.ubuntu.findLigatureRanges(line);
-    return line.length;
+test('Iosevka: no-ligatures (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/iosevka-regular.ttf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-test('Ubuntu Mono: noLigatures.txt', (context, iteration) => {
-    const line = noLigatures[iteration % noLigatures.length];
-    context.ubuntu.findLigatureRanges(line);
-    return line.length;
+test('Monoid: code', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/Monoid-Regular.ttf')));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
 });
 
-run();
+test('Monoid: no-ligatures', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/Monoid-Regular.ttf')));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
+});
+
+test('Monoid: code (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/Monoid-Regular.ttf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
+});
+
+test('Monoid: no-ligatures (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/Monoid-Regular.ttf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
+});
+
+test('Ubuntu Mono: code', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf')));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
+});
+
+test('Ubuntu Mono: no-ligatures', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf')));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
+});
+
+test('Ubuntu Mono: code (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = code[iteration % code.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
+});
+
+test('Ubuntu Mono: no-ligatures (cache)', t => {
+    t.setup(() =>
+        fontLigatures.loadFile(
+            path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf'),
+            { cacheSize }
+        ));
+
+    t.run((font, iteration) => {
+        const line = noLigatures[iteration % noLigatures.length];
+        font.findLigatureRanges(line);
+        return line.length;
+    });
+});
+
+run(1000);

--- a/bench/harness.js
+++ b/bench/harness.js
@@ -1,58 +1,103 @@
 const chalk = require('chalk');
 const stats = require('simple-statistics');
 const columnify = require('columnify');
-
-let setupOperation;
-async function setup(operation) {
-    setupOperation = operation;
-}
+const prettyBytes = require('pretty-bytes');
 
 const tests = [];
-function test(name, operation) {
-    tests.push({ name, operation });
+function test(name, fn) {
+    let fns = {};
+
+    const context = {
+        setup(setupFn) {
+            fns.setup = setupFn;
+        },
+        run(operation) {
+            fns.operation = operation;
+        }
+    };
+
+    fn(context);
+
+    tests.push({ name, setup: fns.setup, operation: fns.operation });
 }
 
 async function run(iterations = 1000) {
-    const context = await setupOperation();
+    global.gc();
+
+    console.log(`Starting memory: ${prettyBytes(process.memoryUsage().heapUsed)}\n`);
 
     for (const test of tests) {
-        test.results = [];
-        test.lengths = [];
+        test.data = {};
+
+        global.gc();
+        test.data.startingMemory = process.memoryUsage().heapUsed;
+
+        const context = await test.setup();
+
+        global.gc();
+        test.data.postLoadMemory = process.memoryUsage().heapUsed;
+
+        const results = [];
+        const lengths = [];
 
         for (let i = 0; i < iterations; i++) {
             const start = process.hrtime();
             const length = test.operation(context, i);
             const elapsed = process.hrtime(start);
-            test.results.push(elapsed[0] * 1e3 + elapsed[1] * 1e-6);
-            test.lengths.push(length);
+            results.push(elapsed[0] * 1e3 + elapsed[1] * 1e-6);
+            lengths.push(length);
         }
+
+        const chars = results.map((val, index) =>
+            Array(lengths[index]).fill(val / lengths[index]));
+
+        const allChars = [];
+        for (const charArr of chars) {
+            allChars.push(...charArr);
+        }
+
+        test.data.avg = stats.mean(results);
+        test.data.stdev = stats.standardDeviation(results);
+        test.data.pct5 = stats.quantile(results, 0.05);
+        test.data.pct50 = stats.quantile(results, 0.50);
+        test.data.pct95 = stats.quantile(results, 0.95);
+        test.data.charAvg = stats.mean(allChars);
+        test.data.charStdev = stats.standardDeviation(allChars);
+
+        global.gc();
+
+        // This is only done to prevent the font (and its cache) from being GC'd
+        test.context = context;
+        delete test.context;
+
+        test.data.endingMemory = process.memoryUsage().heapUsed;
     }
 
     console.log(columnify(
-        tests.map(test => {
-            const chars = test.results.map((val, index) =>
-                Array(test.lengths[index]).fill(val / test.lengths[index]));
-
-            const allChars = [];
-            for (const charArr of chars) {
-                allChars.push(...charArr);
-            }
-
-            return {
+        [
+            {
+                name: '-'.repeat(Math.max(...tests.map(t => t.name.length))),
+                avg: '------',
+                '50%': '------',
+                '95%': '------',
+                'avg (char)': '----------',
+                'mem start': '---------',
+                'mem increase': '------------',
+            },
+            ...tests.map(test => ({
                 name: chalk.bold(test.name),
-                avg: chalk.magenta(stats.mean(test.results).toFixed(4)),
-                stdev: chalk.magenta(stats.standardDeviation(test.results).toFixed(4)),
-                '5%': chalk.cyan(stats.quantile(test.results, 0.05).toFixed(4)),
-                '50%': chalk.cyan(stats.quantile(test.results, 0.50).toFixed(4)),
-                '95%': chalk.cyan(stats.quantile(test.results, 0.95).toFixed(4)),
-                'avg (char)': chalk.magenta(stats.mean(allChars).toFixed(7)),
-                'stdev (char)': chalk.magenta(stats.standardDeviation(allChars).toFixed(7)),
-            };
-        }),
+                avg: chalk.cyan(test.data.avg.toFixed(4)),
+                '50%': chalk.cyan(test.data.pct50.toFixed(4)),
+                '95%': chalk.cyan(test.data.pct95.toFixed(4)),
+                'avg (char)': chalk.cyan(test.data.charAvg.toFixed(7)),
+                'mem start': chalk.magenta(prettyBytes(test.data.postLoadMemory)),
+                'mem increase': chalk.magenta(prettyBytes(test.data.endingMemory - test.data.postLoadMemory)),
+            }))
+        ],
         {
-            columnSplitter: '   '
+            columnSplitter: ' | '
         }
     ));
 }
 
-module.exports = { setup, test, run };
+module.exports = { test, run };

--- a/package-lock.json
+++ b/package-lock.json
@@ -647,6 +647,12 @@
         "@types/lodash": "4.14.108"
       }
     },
+    "@types/lru-cache": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.0.tgz",
+      "integrity": "sha512-qY2IbsE6q6iWdmUyRtFqMWc2CoynQzUQz25EmHW8V9K7mq9xP6ON1ay1yDbCXlgpb0y4UJqV2EbtiMbn6nMXAg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "8.10.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.11.tgz",
@@ -2711,7 +2717,7 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -4863,10 +4869,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-      "dev": true,
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -8566,6 +8571,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "pretty-bytes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.0.0.tgz",
+      "integrity": "sha512-y2vTE3T7ODiNA8FL/x6QpSuG0yKu6M6aIXUCbKzFZ4/6EG4CazYu/eyMWweukcCRTrOOypBe5R8xZU0aE0X9JA==",
+      "dev": true
+    },
     "pretty-ms": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
@@ -8610,8 +8621,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "punycode": {
       "version": "1.4.1",
@@ -10376,8 +10386,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "prerelease": "npm run build",
     "release": "semantic-release",
-    "bench": "node bench/all.js"
+    "bench": "node --expose-gc bench/all.js"
   },
   "keywords": [
     "font",
@@ -45,6 +45,7 @@
     "debug": "^3.1.0",
     "font-finder": "^1.0.1",
     "lodash.clonedeep": "^4.5.0",
+    "lru-cache": "^4.1.3",
     "opentype.js": "^0.8.0"
   },
   "devDependencies": {
@@ -58,6 +59,7 @@
     "@semantic-release/npm": "^3.2.4",
     "@types/debug": "0.0.30",
     "@types/lodash.clonedeep": "^4.5.3",
+    "@types/lru-cache": "^4.1.0",
     "@types/node": "^8.10.10",
     "@types/opentype.js": "^0.7.0",
     "@types/sinon": "^4.3.1",
@@ -68,6 +70,7 @@
     "husky": "^0.14.3",
     "nyc": "^11.7.1",
     "opener": "^1.4.3",
+    "pretty-bytes": "^5.0.0",
     "rimraf": "^2.6.2",
     "semantic-release": "^15.1.8",
     "simple-statistics": "^6.0.0",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -325,6 +325,48 @@ for (const { font, input, glyphs, ranges } of [
     });
 }
 
+test('findLigatures() caches successive calls correctly', async t => {
+    const font = await load('Fira Code', { cacheSize: 100 });
+    const result1 = font.findLigatures('in --> out');
+    const result2 = font.findLigatures('in --> out');
+    t.deepEqual(result1, result2);
+});
+
+test('findLigatureRanges() caches successive calls correctly', async t => {
+    const font = await load('Fira Code', { cacheSize: 100 });
+    const result1 = font.findLigatureRanges('in --> out');
+    const result2 = font.findLigatureRanges('in --> out');
+    t.deepEqual(result1, result2);
+});
+
+test('caches calls to findLigatures() after findLigatureRanges() correctly', async t => {
+    const uncached = await load('Fira Code');
+    const uncachedResult1 = uncached.findLigatureRanges('in --> out');
+    const uncachedResult2 = uncached.findLigatures('in --> out');
+
+    const font = await load('Fira Code', { cacheSize: 100 });
+    const result1 = font.findLigatureRanges('in --> out');
+    const result2 = font.findLigatures('in --> out');
+
+    t.deepEqual(result1, uncachedResult1);
+    t.deepEqual(result2, uncachedResult2);
+    t.deepEqual(result1, result2.contextRanges);
+});
+
+test('caches calls to findLigatureRanges() after findLigatures() correctly', async t => {
+    const uncached = await load('Fira Code');
+    const uncachedResult1 = uncached.findLigatures('in --> out');
+    const uncachedResult2 = uncached.findLigatureRanges('in --> out');
+
+    const font = await load('Fira Code', { cacheSize: 100 });
+    const result1 = font.findLigatures('in --> out');
+    const result2 = font.findLigatureRanges('in --> out');
+
+    t.deepEqual(result1, uncachedResult1);
+    t.deepEqual(result2, uncachedResult2);
+    t.deepEqual(result1.contextRanges, result2);
+});
+
 test('throws if the font is not found', async t => {
     try {
         await load('Nonexistant');

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,14 @@ export interface Font {
     findLigatureRanges(text: string): [number, number][];
 }
 
+export interface Options {
+    /**
+     * Optional size of previous results to store, measured in total number of
+     * characters from input strings. Defaults to no cache (0)
+     */
+    cacheSize?: number;
+}
+
 export interface LookupTree {
     individual: {
         [glyphId: string]: LookupTreeEntry;


### PR DESCRIPTION
Adds an options object to the top-level `load` and `loadFile` calls with a single key that defines an optional cache size in terms of the length of the input text. It is turned off by default.

The benchmarks have been updated to include cached and uncached test runs and include an attempt to determine the memory impact of caching. That being said, the memory numbers are pretty unreliable at the moment.

Instead, I did a test run with heap dumps generated after each test. The size of the cache as measured by `cacheSize` and memory are included below:

Input | Cache Size | Memory
----- | ------------ | ---------
code | 9502 | 63 KB
no-ligatures | 3046 | 23 KB

Based on this, a cache size of 100,000 (about 10 large screens' worth of text) should fit within about 6-7 MB. For comparison, the font data itself takes up 5-10 MB depending on the font. The overall test run results are included below.

Related: #2 

NAME                              | AVG    | 50%    | 95%    | AVG (CHAR) | MEM START | MEM INCREASE
--------------------------------- | ------ | ------ | ------ | ---------- | --------- | ------------
Fira Code: code                   | 0.0604 | 0.0210 | 0.2225 | **0.0014629**  | 19.1 MB   | 1.01 MB
Fira Code: no-ligatures           | 0.0336 | 0.0260 | 0.0790 | **0.0003637**  | 19.5 MB   | 753 kB
Fira Code: code (cache)           | 0.0319 | 0.0020 | 0.1240 | **0.0007724**  | 20.3 MB   | -542 kB
Fira Code: no-ligatures (cache)   | 0.0094 | 0.0040 | 0.0090 | **0.0001023**  | 19.6 MB   | 762 kB
Iosevka: code                     | 0.0235 | 0.0100 | 0.0655 | **0.0005691**  | 24.1 MB   | -718 kB
Iosevka: no-ligatures             | 0.0126 | 0.0070 | 0.0280 | **0.0001366**  | 23.3 MB   | 738 kB
Iosevka: code (cache)             | 0.0176 | 0.0030 | 0.0420 | **0.0004254**  | 24.2 MB   | -645 kB
Iosevka: no-ligatures (cache)     | 0.0041 | 0.0020 | 0.0095 | **0.0000443**  | 23.6 MB   | 773 kB
Monoid: code                      | 0.0247 | 0.0100 | 0.0590 | **0.0005975**  | 15.6 MB   | -1.13 MB
Monoid: no-ligatures              | 0.0226 | 0.0090 | 0.0600 | **0.0002446**  | 14.8 MB   | 438 kB
Monoid: code (cache)              | 0.0149 | 0.0020 | 0.0445 | **0.0003614**  | 15.6 MB   | -807 kB
Monoid: no-ligatures (cache)      | 0.0037 | 0.0020 | 0.0060 | **0.0000397**  | 14.8 MB   | 427 kB
Ubuntu Mono: code                 | 0.0020 | 0.0020 | 0.0030 | **0.0000481**  | 16.5 MB   | -1.26 MB
Ubuntu Mono: no-ligatures         | 0.0021 | 0.0020 | 0.0050 | **0.0000227**  | 15.6 MB   | 185 kB
Ubuntu Mono: code (cache)         | 0.0018 | 0.0020 | 0.0020 | **0.0000441**  | 16.4 MB   | -1.16 MB
Ubuntu Mono: no-ligatures (cache) | 0.0020 | 0.0020 | 0.0040 | **0.0000220**  | 15.6 MB   | 211 kB