### PR TITLE
test(benchmark): prime cache before cached tests and increase iterations

### DIFF
--- a/bench/all.js
+++ b/bench/all.js
@@ -33,11 +33,19 @@ test('Fira Code: no-ligatures', t => {
 });
 
 test('Fira Code: code (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/FiraCode-Regular.otf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of code) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = code[iteration % code.length];
@@ -47,11 +55,19 @@ test('Fira Code: code (cache)', t => {
 });
 
 test('Fira Code: no-ligatures (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/FiraCode-Regular.otf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of noLigatures) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = noLigatures[iteration % noLigatures.length];
@@ -83,11 +99,19 @@ test('Iosevka: no-ligatures', t => {
 });
 
 test('Iosevka: code (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/iosevka-regular.ttf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of code) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = code[iteration % code.length];
@@ -97,11 +121,19 @@ test('Iosevka: code (cache)', t => {
 });
 
 test('Iosevka: no-ligatures (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/iosevka-regular.ttf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of noLigatures) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = noLigatures[iteration % noLigatures.length];
@@ -133,11 +165,19 @@ test('Monoid: no-ligatures', t => {
 });
 
 test('Monoid: code (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/Monoid-Regular.ttf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of code) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = code[iteration % code.length];
@@ -147,11 +187,19 @@ test('Monoid: code (cache)', t => {
 });
 
 test('Monoid: no-ligatures (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/Monoid-Regular.ttf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of noLigatures) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = noLigatures[iteration % noLigatures.length];
@@ -183,11 +231,19 @@ test('Ubuntu Mono: no-ligatures', t => {
 });
 
 test('Ubuntu Mono: code (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of code) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = code[iteration % code.length];
@@ -197,11 +253,19 @@ test('Ubuntu Mono: code (cache)', t => {
 });
 
 test('Ubuntu Mono: no-ligatures (cache)', t => {
-    t.setup(() =>
-        fontLigatures.loadFile(
+    t.setup(async () => {
+        const font = await fontLigatures.loadFile(
             path.join(__dirname, '../fonts/UbuntuMono-Regular.ttf'),
             { cacheSize }
-        ));
+        );
+
+        // Prime cache
+        for (const line of noLigatures) {
+            font.findLigatureRanges(line);
+        }
+
+        return font;
+    });
 
     t.run((font, iteration) => {
         const line = noLigatures[iteration % noLigatures.length];
@@ -210,4 +274,4 @@ test('Ubuntu Mono: no-ligatures (cache)', t => {
     });
 });
 
-run(1000);
+run(10000);


### PR DESCRIPTION
This fully primes the cache before cached test runs so that the test isn't impacted by the uncached times of the first pass through the input and doesn't vary as much with varying numbers of iterations.

This also bumps the number of iterations per test up from 1k to 10k to reduce the impact of the first call, which is quite slow (presumably because it's unoptimized).

Updated benchmark numbers:

NAME                              | AVG    | 50%    | 95%    | AVG (CHAR) | MEM START | MEM INCREASE
--------------------------------- | ------ | ------ | ------ | ---------- | --------- | ------------
Fira Code: code                   | 0.0365 | 0.0190 | 0.1225 | 0.0008904  | 18.1 MB   | 7.26 MB
Fira Code: no-ligatures           | 0.0270 | 0.0240 | 0.0500 | 0.0002920  | 25.4 MB   | 9.9 MB
Fira Code: code (cache)           | 0.0020 | 0.0020 | 0.0030 | 0.0000487  | 35.4 MB   | -9.82 MB
Fira Code: no-ligatures (cache)   | 0.0018 | 0.0020 | 0.0020 | 0.0000197  | 25.6 MB   | 9.87 MB
Iosevka: code                     | 0.0106 | 0.0060 | 0.0300 | 0.0002596  | 21.4 MB   | 7.33 MB
Iosevka: no-ligatures             | 0.0103 | 0.0070 | 0.0160 | 0.0001113  | 21.3 MB   | 17.2 MB
Iosevka: code (cache)             | 0.0019 | 0.0020 | 0.0020 | 0.0000452  | 21.5 MB   | 7.2 MB
Iosevka: no-ligatures (cache)     | 0.0019 | 0.0020 | 0.0030 | 0.0000210  | 21.5 MB   | 17.2 MB
Monoid: code                      | 0.0071 | 0.0050 | 0.0160 | 0.0001728  | 12.9 MB   | 6.79 MB
Monoid: no-ligatures              | 0.0101 | 0.0090 | 0.0170 | 0.0001098  | 12.7 MB   | 16.8 MB
Monoid: code (cache)              | 0.0016 | 0.0010 | 0.0020 | 0.0000392  | 12.8 MB   | 6.99 MB
Monoid: no-ligatures (cache)      | 0.0023 | 0.0020 | 0.0040 | 0.0000252  | 12.8 MB   | 16.8 MB
Ubuntu Mono: code                 | 0.0016 | 0.0010 | 0.0020 | 0.0000386  | 13.7 MB   | 6.58 MB
Ubuntu Mono: no-ligatures         | 0.0015 | 0.0010 | 0.0020 | 0.0000164  | 13.5 MB   | 16.6 MB
Ubuntu Mono: code (cache)         | 0.0018 | 0.0020 | 0.0030 | 0.0000445  | 13.5 MB   | 6.75 MB
Ubuntu Mono: no-ligatures (cache) | 0.0016 | 0.0010 | 0.0020 | 0.0000169  | 13.6 MB   | 16.6 MB