### PR TITLE
fix: check if font.tables.gsub is undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,13 +30,12 @@ class FontImpl implements Font {
             });
         }
 
-        const caltFeatures = this._font.tables.gsub.features.filter(f => f.tag === 'calt');
+        const caltFeatures = this._font.tables.gsub && this._font.tables.gsub.features.filter(f => f.tag === 'calt') || [];
         const lookupIndices: number[] = caltFeatures
             .reduce((acc, val) => [...acc, ...val.feature.lookupListIndexes], []);
-        const lookupGroups = this._font.tables.gsub.lookups
-            .filter((l, i) => lookupIndices.some(idx => idx === i));
 
-        const allLookups = this._font.tables.gsub.lookups;
+        const allLookups = this._font.tables.gsub && this._font.tables.gsub.lookups || [];
+        const lookupGroups = allLookups.filter((l, i) => lookupIndices.some(idx => idx === i));
 
         for (const [index, lookup] of lookupGroups.entries()) {
             const trees: LookupTree[] = [];


### PR DESCRIPTION
After loading a font using `opentype.load` the `gsub` key may or may not be present in `font.tables`

https://github.com/opentypejs/opentype.js/blob/dac8c6b13b6e43bf132a9c23b757b573c6d5ad26/src/opentype.js#L339-L344

If `gsub` is undefined it results in `Cannot read property 'features' of undefined` error.
In https://github.com/vercel/hyper we're facing this error (we use xterm-addon-ligature which uses this module)
See https://github.com/vercel/hyper/issues/4360#issuecomment-605370067

So I added a check for `gsub` and default value if it's undefined.

Let me know if I need to make some changes to improve this pr.