### PR TITLE
feat: enable usage in browser by providing font array buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ can be used to find ligature information.
       within the parser. The size is measured by the length of the input text
       for each call. Turned off by default.
 
+### `loadBuffer(buffer, [options])`
+
+Loads the font from it's binary data, returning a [Font](#font) that
+can be used to find ligature information.
+
+**Params**
+
+ * `buffer` [*ArryaBuffer*] - Binary data of the font file as an ArrayBuffer
+ * `options` [*object*] - Optional configuration object containing the following
+   keys:
+    * `cacheSize` [*number*] - The amount of data from previous results to cache
+      within the parser. The size is measured by the length of the input text
+      for each call. Turned off by default.
+
 ### Font
 
 Object returned by `load()`. Includes the following methods:

--- a/package-lock.json
+++ b/package-lock.json
@@ -811,9 +811,9 @@
       }
     },
     "@types/lru-cache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.0.tgz",
-      "integrity": "sha512-qY2IbsE6q6iWdmUyRtFqMWc2CoynQzUQz25EmHW8V9K7mq9xP6ON1ay1yDbCXlgpb0y4UJqV2EbtiMbn6nMXAg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
       "dev": true
     },
     "@types/node": {
@@ -2901,9 +2901,27 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
+        "lru-cache": "^4.0.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "cryptiles": {
@@ -5697,12 +5715,11 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "yallist": "^4.0.0"
       }
     },
     "make-dir": {
@@ -7912,7 +7929,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -9875,9 +9893,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "font-finder": "^1.0.3",
-    "lru-cache": "^4.1.3",
+    "lru-cache": "^6.0.0",
     "opentype.js": "^0.8.0"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
     "@semantic-release/git": "^4.0.3",
     "@semantic-release/github": "^4.4.2",
     "@semantic-release/npm": "^3.4.1",
-    "@types/lru-cache": "^4.1.0",
+    "@types/lru-cache": "^5.1.0",
     "@types/node": "^8.10.10",
     "@types/opentype.js": "^0.7.0",
     "@types/sinon": "^4.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import * as util from 'util';
 import * as opentype from 'opentype.js';
-import * as fontFinder from 'font-finder';
 import * as lru from 'lru-cache';
 
 import { Font, LigatureData, FlattenedLookupTree, LookupTree, Options } from './types';
@@ -256,7 +254,7 @@ class FontImpl implements Font {
 export async function load(name: string, options?: Options): Promise<Font> {
     // We just grab the first font variant we find for now.
     // TODO: allow users to specify information to pick a specific variant
-    const [fontInfo] = await fontFinder.listVariants(name);
+    const [fontInfo] = await import('font-finder').then(fontFinder => fontFinder.listVariants(name));
 
     if (!fontInfo) {
         throw new Error(`Font ${name} not found`);
@@ -272,8 +270,8 @@ export async function load(name: string, options?: Options): Promise<Font> {
  * @param path Path to the file containing the font
  */
 export async function loadFile(path: string, options?: Options): Promise<Font> {
-    const font = await util.promisify<string, opentype.Font>(opentype.load as any)(path);
-    return new FontImpl(font, {
+    const font = await import('util').then(util => util.promisify<string, opentype.Font | undefined>(opentype.load)(path));
+    return new FontImpl(font!, {
         cacheSize: 0,
         ...options
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,4 +279,18 @@ export async function loadFile(path: string, options?: Options): Promise<Font> {
     });
 }
 
+/**
+ * Load the font from it's binary data. The returned value can be used to find
+ * ligatures for the font.
+ *
+ * @param buffer ArrayBuffer of the font to load
+ */
+export function loadBuffer(buffer: ArrayBuffer, options?: Options): Font {
+    const font = opentype.parse(buffer);
+    return new FontImpl(font, {
+        cacheSize: 0,
+        ...options
+    });
+}
+
 export { Font, LigatureData, Options };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,13 @@ class FontImpl implements Font {
     private _font: opentype.Font;
     private _lookupTrees: { tree: FlattenedLookupTree; processForward: boolean; }[] = [];
     private _glyphLookups: { [glyphId: string]: number[] } = {};
-    private _cache?: lru.Cache<string, LigatureData | [number, number][]>;
+    private _cache?: lru<string, LigatureData | [number, number][]>;
 
     constructor(font: opentype.Font, options: Required<Options>) {
         this._font = font;
 
         if (options.cacheSize > 0) {
-            this._cache = lru({
+            this._cache = new lru({
                 max: options.cacheSize,
                 length: ((val: LigatureData | [number, number][], key: string) => key.length) as any
             });


### PR DESCRIPTION
Added a function to create the Font object from ArrayBuffer of the font
Adding this to make it possible to use this library in the browser with font data from font access API, see this [comment](https://github.com/xtermjs/xterm.js/issues/958#issuecomment-761813922) in xtermjs/xterm.js#958