### PR TITLE
fix infinite loop in `getRangeGlyphClass`

### DIFF
--- a/src/processors/classDef.ts
+++ b/src/processors/classDef.ts
@@ -41,6 +41,7 @@ function getRangeGlyphClass(table: ClassDefTable.Format2, glyphId: [number, numb
                 result.set([classStart, search], currentClass);
             }
         }
+        search++;
     }
 
     if (search - classStart <= 1) {


### PR DESCRIPTION
Fixes #23 

Just adding `search++;` similar to https://github.com/princjef/font-ligatures/blob/c9ad109fb9d873e67dc81c23a87fe7fb696d5f8b/src/processors/substitution.ts#L29

However, I think both the places should also have something like
```js
start = search;
currentClass = clazz;
```
Can add that too if you think it sounds correct.